### PR TITLE
Fix code scanning alert no. 3: Failure to use HTTPS or SFTP URL in Maven artifact upload/download

### DIFF
--- a/init.settings.xml
+++ b/init.settings.xml
@@ -25,19 +25,19 @@
         <pluginRepository>
           <id>twdata-m2-repository</id>
           <name>twdata.org Maven 2 Repository</name>
-          <url>http://twdata-m2-repository.googlecode.com/svn/</url>
+          <url>https://twdata-m2-repository.googlecode.com/svn/</url>
         </pluginRepository>
         <pluginRepository>
           <id>scala-tools.org</id>
           <name>Scala-tools Maven2 Repository</name>
-          <url>http://scala-tools.org/repo-releases</url>
+          <url>https://scala-tools.org/repo-releases</url>
         </pluginRepository>
       </pluginRepositories>
       <repositories>
         <repository>
           <id>scala-tools.org</id>
           <name>Scala-tools Maven2 Repository</name>
-          <url>http://scala-tools.org/repo-releases</url>
+          <url>https://scala-tools.org/repo-releases</url>
         </repository>
       </repositories>
     </profile>


### PR DESCRIPTION
Fixes [https://github.com/hmahal/noop/security/code-scanning/3](https://github.com/hmahal/noop/security/code-scanning/3)

To fix the problem, we need to update the URLs in the Maven settings file to use HTTPS instead of HTTP. This ensures that all communications with the repositories are encrypted, protecting against potential MITM attacks.

- Locate the URLs in the `init.settings.xml` file that use the HTTP protocol.
- Replace the HTTP URLs with their HTTPS counterparts.
- Ensure that the new URLs are correct and accessible over HTTPS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
